### PR TITLE
fix: repair release pipeline and reduce dependabot volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 3
     labels:
       - "⬆️ dependencies"
     assignees:
@@ -18,37 +17,22 @@ updates:
     ignore:
       # Keep Obsidian at current version - controlled via package.json overrides
       - dependency-name: "obsidian"
-      # Prevent major TypeScript version bumps - only allow minor/patch updates
+      # Only allow patch/minor updates for TypeScript - major versions may break @typescript-eslint compatibility
       - dependency-name: "typescript"
-        update-types:
-          - "version-update:semver-major"
+        update-types: ["version-update:semver-major"]
     groups:
-      # Group all TypeScript/ESLint related updates
-      typescript-eslint:
-        patterns:
-          - "@typescript-eslint/*"
-          - "typescript"
-      # Group all Jest related updates
-      jest:
-        patterns:
-          - "jest*"
-          - "@types/jest"
-          - "ts-jest"
-      # Group development tools
-      dev-tools:
-        patterns:
-          - "prettier"
-          - "husky"
-          - "lint-staged"
-          - "eslint"
+      # Single group for all dev dependencies - one PR per cycle rather than
+      # several, since everything here is a build/test tool
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 2
     labels:
       - "⬆️ dependencies"
     assignees:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,18 +4,14 @@ on:
   push:
     branches:
       - 'main'
-    paths:
-      - '*.js'
-      - '*.mjs'
-      - '*.json'
-      - '*.ts'
-      - '*.md'
-      - 'docs/**'
-      - 'src/**'
+    # No paths filter: should_release already gates on commit type, and a filter
+    # here strands commits that only touch .github/**
 
 permissions:
   contents: write
   id-token: write
+  # Required to record provenance attestations for the release assets
+  attestations: write
 
 jobs:
   Build:
@@ -73,6 +69,15 @@ jobs:
       - name: Build
         if: steps.version.outputs.should_release == 'true'
         run: npm run build
+      - name: Attest Build Provenance
+        if: steps.version.outputs.should_release == 'true'
+        uses: actions/attest-build-provenance@v4
+        with:
+          # All three files are published as release assets, so all are attested
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
       - name: Generate Release Notes
         if: steps.version.outputs.should_release == 'true'
         id: release_notes

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,8 +13,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a PAT, and it must exist as a *Dependabot* secret as well as an
+          # Actions one - dependabot-triggered runs cannot see Actions secrets, and
+          # merges made with GITHUB_TOKEN do not trigger build.yml
+          GH_TOKEN: ${{ secrets.PAT }}
+      - name: Flag major update for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "::notice::Major update to ${{ steps.metadata.outputs.dependency-names }} - not auto-merged, review and merge manually"
+          gh pr comment "$PR_URL" --body "🚧 Major version update — auto-merge is deliberately skipped. Review the changelog and merge manually."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,9 @@ jobs:
         run: |
           npm audit --audit-level=moderate
         continue-on-error: true
+      - name: Lint
+        run: |
+          npm run lint
       - name: Build
         run: |
           npm run build
@@ -147,5 +150,5 @@ jobs:
 
             ---
 
-            <sub>This PR will ${{ steps.version.outputs.should_release == 'true' && format('trigger a **{0}** version bump from `{1}` to `{2}`', steps.version.outputs.bump_type, steps.version.outputs.previous_version, steps.version.outputs.version) || 'not trigger a release (only docs/test/chore/build/ci/style/revert changes)' }}</sub>
+            <sub>Merging this PR will ${{ steps.version.outputs.should_release == 'true' && format('release a **{0}** bump, `{1}` → `{2}`. This covers everything unreleased on `main`, not only the commits in this PR.', steps.version.outputs.bump_type, steps.version.outputs.previous_version, steps.version.outputs.version) || 'not release (nothing unreleased on `main` beyond docs/test/chore/build/ci/style/revert changes)' }}</sub>
           comment-tag: version_impact


### PR DESCRIPTION
Ports the CI and dependabot work already landed in `obsidian-auto-periodic-notes`.

## #160 — dependabot volume (`.github/dependabot.yml`)

- Monthly cadence on both npm and github-actions.
- Four npm groups collapsed into a single `dev-dependencies` group (minor/patch).
- PR limits dropped to 3 (npm) and 2 (github-actions).

## #162 — release pipeline (workflows)

1. Auto-merge uses `secrets.PAT` — merges made with `GITHUB_TOKEN` do not start workflow runs, so no auto-merged PR has ever produced a build.
2. `build.yml` `paths:` filter dropped entirely; `should_release` already gates on commit type, and the filter stranded any commit touching only `.github/**`.
3. Version Impact comment reworded to say it covers everything unreleased on `main`, not the commits in this PR alone. Note: upstream did **not** change `calculate-version.sh` to accept a range as the issue proposed — with the paths filter fixed the figure is accurate again, so only the wording changed. This PR matches that.

## Also carried across from the same batch

- Major dependency updates skip auto-merge and get a "review manually" comment, via `dependabot/fetch-metadata@v3`.
- Build provenance attestation for release assets — extended to `styles.css`, which this repo ships and auto-periodic-notes does not.
- `npm run lint` step in `test.yml`. Lint passes clean locally.

## Before merging

`PAT` exists here as an Actions secret but **not** as a Dependabot secret (`gh secret list --app dependabot` is empty). The auto-merge workflow triggers on `pull_request`, so dependabot runs only see Dependabot secrets — without it `secrets.PAT` resolves empty and auto-merge silently fails, which is the same class of failure as the bug being fixed. Run `gh secret set PAT --app dependabot` first.

Then verify after the next dependabot merge that a Build run actually appears.

Closes #160
Closes #162

https://claude.ai/code/session_0178Yw53kDpLamwUkm5D6kem