### PR TITLE
feat: make the Periodic Notes plugin optional

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 repository:
   name: obsidian-auto-tasks
-  description: Obsidian plugin to combine periodic notes with tags and tasks to automatically manage your daily, weekly and project TODO lists. Requires the "Periodic Notes" and "Tasks" plugins.
+  description: Obsidian plugin to combine periodic notes with tags and tasks to automatically manage your daily, weekly and project TODO lists. Optionally uses the "Periodic Notes" and "Tasks" plugins.
   topics: obsidian, typescript, plugin, notes, pkm
   private: false
   has_issues: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Combine periodic notes with tags and tasks to automatically manage your daily, weekly and project TODO lists.
 
-Designed to work with [Obsidian](https://obsidian.md), requires the [Periodic Notes](https://github.com/liamcain/obsidian-periodic-notes) plugin. The [Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) and [Kanban](https://github.com/mgmeyers/obsidian-kanban) plugins are optional.
+Designed to work with [Obsidian](https://obsidian.md). The [Periodic Notes](https://github.com/liamcain/obsidian-periodic-notes), [Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) and [Kanban](https://github.com/mgmeyers/obsidian-kanban) plugins are all optional.
+
+When the Periodic Notes plugin is installed, this plugin respects its settings, using the templates, format and location you have selected. Without it, daily and weekly notes are created using Obsidian's own defaults - `YYYY-MM-DD` for daily and `gggg-[W]ww` for weekly (or your [Calendar](https://github.com/liamcain/obsidian-calendar-plugin) plugin settings, if you have it), each in the vault root with no template. This is provided through an [abstract provider](https://github.com/jamiefdhurst/obsidian-periodic-notes-provider) for the plugin.
 
 This plugin works well with the [Auto Periodic Notes](https://github.com/jamiefdhurst/obsidian-auto-periodic-notes) plugin.
 
@@ -38,7 +40,7 @@ All the tasks within the periodic notes and elsewhere in the vault can be collat
 
 ![Example of Settings screen within Obsidian](/docs/settings.png)
 
-Depending on your Periodic Notes configuration, the plugin supports working with both daily and weekly notes - these must be enabled in the Periodic Notes plugin to appear. For each type of note you can choose to carry over your daily tasks, whether to automatically add any tasks from anywhere in your vault that are due either that day or week, and how to read the tasks from your existing periodic note.
+The plugin supports working with both daily and weekly notes. If you have the Periodic Notes plugin installed, only the note types you have enabled there appear; without it, both are available. For each type of note you can choose to carry over your daily tasks, whether to automatically add any tasks from anywhere in your vault that are due either that day or week, and how to read the tasks from your existing periodic note.
 
 When the Kanban plugin is available, you can choose to sync all of the tasks within your vault automatically to a board, which will be created for you.
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Auto Tasks",
   "version": "0.8.3",
   "minAppVersion": "1.6.6",
-  "description": "Combine periodic notes with tags and tasks to automatically manage your daily, weekly and project TODO lists. Requires the Periodic Notes and Tasks plugins.",
+  "description": "Combine periodic notes with tags and tasks to automatically manage your daily, weekly and project TODO lists. Optionally uses the Periodic Notes and Tasks plugins.",
   "author": "Jamie Hurst",
   "authorUrl": "https://jamiehurst.co.uk",
   "isDesktopOnly": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "obsidian-periodic-notes-provider": "^2.0.0"
+        "obsidian-periodic-notes-provider": "^2.1.0"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -6486,9 +6486,9 @@
       "license": "0BSD"
     },
     "node_modules/obsidian-periodic-notes-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/obsidian-periodic-notes-provider/-/obsidian-periodic-notes-provider-2.0.0.tgz",
-      "integrity": "sha512-KjsgGLcHyRTQ3obDwQB8Vh06YQ34pJLtlEa5Da7DkATVcH7jZbvXyiOwdB1gy/G7rjvzEJ2/iakWkiMN4oW8Aw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/obsidian-periodic-notes-provider/-/obsidian-periodic-notes-provider-2.1.0.tgz",
+      "integrity": "sha512-BNq8ulXxw4X6IwubImFeTpQXUoa72JLobm31FMlKcxtgO29HnF0bvipKMlYPJe0GizeoCBDQva6z8+rBI51ORA==",
       "license": "MIT",
       "dependencies": {
         "obsidian-daily-notes-interface": "0.9.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-auto-tasks",
   "version": "0.8.3",
-  "description": "Combine periodic notes with tags and tasks to automatically manage your daily, weekly and project TODO lists. Requires the Periodic Notes and Tasks plugins.",
+  "description": "Combine periodic notes with tags and tasks to automatically manage your daily, weekly and project TODO lists. Optionally uses the Periodic Notes and Tasks plugins.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/jamiefdhurst/obsidian-auto-tasks#readme",
   "dependencies": {
-    "obsidian-periodic-notes-provider": "^2.0.0"
+    "obsidian-periodic-notes-provider": "^2.1.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/src/__tests__/tasks/provider.test.ts
+++ b/src/__tests__/tasks/provider.test.ts
@@ -33,7 +33,7 @@ describe('tasks provider', () => {
     dailyNote = jest.fn() as unknown as DailyNote;
     dailyNote.getCurrent = jest.fn();
     dailyNote.getNextDate = jest.fn();
-    dailyNote.getPrevious = jest.fn();
+    dailyNote.getPrevious = jest.fn().mockReturnValue(new TFile());
     dailyNote.isValid = jest.fn();
     weeklyNote = jest.fn() as unknown as WeeklyNote;
     settings = Object.assign({}, DEFAULT_SETTINGS);
@@ -76,6 +76,40 @@ describe('tasks provider', () => {
     await sut.checkAndCopyTasks(settings, new TFile());
 
     expect(vaultRead).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no current note to copy into', async () => {
+    settings.daily.available = true;
+    settings.daily.carryOver = true;
+    jest.spyOn(dailyNote, 'isValid').mockReturnValue(true);
+    jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(undefined);
+    const vaultRead = jest.spyOn(vault, 'read');
+    const vaultProcess = jest.spyOn(vault, 'process');
+
+    await sut.checkAndCopyTasks(settings, new TFile());
+
+    expect(vaultRead).not.toHaveBeenCalled();
+    expect(vaultProcess).not.toHaveBeenCalled();
+  });
+
+  it('adds the header without reading when there is no previous note', async () => {
+    settings.daily.available = true;
+    settings.daily.carryOver = true;
+    settings.daily.header = '## Daily TODOs';
+    jest.spyOn(dailyNote, 'isValid').mockReturnValue(true);
+    jest.spyOn(dailyNote, 'getPrevious').mockReturnValue(undefined);
+    jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(new TFile());
+    const vaultRead = jest.spyOn(vault, 'read');
+    let result;
+    jest.spyOn(vault, 'process').mockImplementation((file, fn, options) => {
+      result = fn('');
+      return Promise.resolve(result);
+    });
+
+    await sut.checkAndCopyTasks(settings, new TFile());
+
+    expect(vaultRead).not.toHaveBeenCalled();
+    expect(result).toEqual(`\n\n## Daily TODOs\n\n`);
   });
 
   it('copies tasks from previous note', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import { Notice, Plugin, TFile, type PluginManifest } from 'obsidian';
+import { Plugin, TFile, type PluginManifest } from 'obsidian';
 import {
-  ObsidianAppWithPlugins,
   PERIODIC_NOTES_EVENT_SETTING_UPDATED,
   PeriodicNotesPluginAdapter,
 } from 'obsidian-periodic-notes-provider';
@@ -31,7 +30,7 @@ export default class AutoTasks extends Plugin {
 
     const vault: ObsidianVault = app.vault;
 
-    this.periodicNotesPlugin = new PeriodicNotesPluginAdapter(app as ObsidianAppWithPlugins);
+    this.periodicNotesPlugin = new PeriodicNotesPluginAdapter(app);
     this.tasksPlugin = new TasksPluginAdapter(app);
     this.kanbanPlugin = new KanbanPluginAdapter(app);
 
@@ -55,12 +54,13 @@ export default class AutoTasks extends Plugin {
   }
 
   async onLayoutReady(): Promise<void> {
-    if (!this.periodicNotesPlugin.isEnabled()) {
-      new Notice(
-        'The Periodic Notes plugin must be installed and available for Auto Tasks to work.',
-        10000
+    // The Periodic Notes plugin is optional - when it is absent the provider
+    // falls back to the native obsidian-daily-notes-interface defaults, so the
+    // plugin still works, it just has no external settings source to read from
+    if (this.periodicNotesPlugin.isNative()) {
+      debug(
+        'Periodic Notes plugin is not available, falling back to native periodic note defaults'
       );
-      return;
     }
 
     debug('Starting initial layout and load');
@@ -144,6 +144,9 @@ export default class AutoTasks extends Plugin {
   }
 
   private syncPeriodicNotesSettings(): void {
+    // Resolves against the Periodic Notes plugin when it is installed, and
+    // against the native defaults otherwise - either way this never throws
+    debug('Resolving the available periodic note types');
     const pluginSettings = this.periodicNotesPlugin.convertSettings();
     this.settings.daily.available = pluginSettings.daily.available;
     this.settings.weekly.available = pluginSettings.weekly.available;

--- a/src/tasks/provider.ts
+++ b/src/tasks/provider.ts
@@ -1,7 +1,8 @@
 import { moment, TAbstractFile } from 'obsidian';
-import { DailyNote, Note, WeeklyNote } from 'obsidian-periodic-notes-provider';
+import { DailyNote, PeriodicNote, WeeklyNote } from 'obsidian-periodic-notes-provider';
 import { DUE, PROGRESS, UPCOMING } from '../kanban/board';
 import { KanbanProvider } from '../kanban/provider';
+import debug from '../log';
 import { IPeriodicitySettings, ISettings } from '../settings';
 import { ObsidianVault } from '../types';
 import { TaskFactory } from './factory';
@@ -37,11 +38,20 @@ export class TasksProvider {
     settings: ISettings,
     periodicitySetting: IPeriodicitySettings,
     file: TAbstractFile,
-    cls: Note
+    cls: PeriodicNote
   ): Promise<void> {
     if (periodicitySetting.available && periodicitySetting.carryOver && cls.isValid(file)) {
-      // Get the previous entry
-      const previousEntryContents: string = await this.vault.read(cls.getPrevious());
+      const newNote = cls.getCurrent();
+      if (newNote === undefined) {
+        debug('No current note to copy tasks into, skipping');
+        return;
+      }
+
+      // Get the previous entry - there may not be one, in which case there is
+      // nothing to carry over, though due tasks can still apply below
+      const previousEntry = cls.getPrevious();
+      const previousEntryContents: string =
+        previousEntry !== undefined ? await this.vault.read(previousEntry) : '';
       const tasks: Task[] = this.factory
         .newCollection(previousEntryContents)
         .getTasksFromLists(periodicitySetting.searchHeaders);
@@ -78,7 +88,7 @@ export class TasksProvider {
       }
 
       // Add them into the new entry
-      await this.vault.process(cls.getCurrent(), (contents) => {
+      await this.vault.process(newNote, (contents) => {
         if (contents.indexOf(periodicitySetting.header + '\n') > -1) {
           return contents.replace(
             periodicitySetting.header + '\n',


### PR DESCRIPTION
Updates `obsidian-periodic-notes-provider` to 2.1.0 and drops the Periodic Notes plugin as a hard dependency, matching the change already landed in `obsidian-auto-periodic-notes`.

## Behaviour

2.1.0 adds a native fallback: when the Periodic Notes plugin is absent, `PeriodicNotesPluginAdapter` resolves settings through `obsidian-daily-notes-interface` defaults instead of throwing, and reports every periodicity as available.

`onLayoutReady` no longer shows a notice and bails when the plugin is missing — it debug-logs the fallback via the new `isNative()` and carries on. Nothing is enabled for the user: daily and weekly are reported as available, but each still has to be turned on in this plugin's own settings.

Descriptions in `package.json`, `manifest.json` and `.github/settings.yml` change from "Requires the Periodic Notes and Tasks plugins" to "Optionally uses…", with README updates covering the no-plugin defaults.

## Two type errors the upgrade surfaced

2.1.0 ships generated declarations instead of the hand-written `index.d.ts`, so `Note` is now `PeriodicNote` and `ObsidianAppWithPlugins` is no longer re-exported (the local type in `src/types.d.ts` is structurally identical, so the constructor cast is dropped).

The old names silently degraded to `any`, which was hiding that `getPrevious()` and `getCurrent()` are both `TFile | undefined` in `src/tasks/provider.ts` — the code passed them straight into `vault.read` / `vault.process`. This matters more now, since a vault without the Periodic Notes plugin is likelier to have no previous note. A missing previous note now carries nothing over rather than reading `undefined`, and a missing current note skips the copy entirely. Both paths have tests, and the test setup that was masking the first case (mocking `read` without mocking `getPrevious`) is fixed.

## Checks

Lint, prettier, build and all 258 tests pass locally. Coverage 89.4% lines / 86.2% branches, above the 80/85 thresholds.

## Not done

- `src/index.ts` is 18% covered — `onLayoutReady` has no tests, so the new native branch is untested here. A pre-existing gap, and a real piece of work given how much that method now does.
- `src/settings/tab.ts:43` still points users at the Periodic Notes plugin settings. That banner is only reachable when the plugin is installed with both types disabled, so it remains accurate.

Commit is `feat:`, so this releases a minor bump: 0.8.2 → 0.9.0.

https://claude.ai/code/session_0178Yw53kDpLamwUkm5D6kem