### PR TITLE
fix: carry tasks over when the core Daily Notes plugin is in use

### DIFF
--- a/src/__tests__/plugins/core-notes.test.ts
+++ b/src/__tests__/plugins/core-notes.test.ts
@@ -1,0 +1,80 @@
+import { Plugin } from 'obsidian';
+import { CoreNotesAdapter } from '../../plugins/core-notes';
+import {
+  InternalPlugin,
+  ObsidianAppWithInternalPlugins,
+  ObsidianAppWithPlugins,
+} from '../../types';
+
+describe('core notes adapter', () => {
+  let app: ObsidianAppWithPlugins & ObsidianAppWithInternalPlugins;
+  let internalPlugins: Map<string, InternalPlugin>;
+
+  let sut: CoreNotesAdapter;
+
+  beforeEach(() => {
+    app = jest.fn() as unknown as ObsidianAppWithPlugins & ObsidianAppWithInternalPlugins;
+    internalPlugins = new Map<string, InternalPlugin>();
+    app.plugins = {
+      enabledPlugins: new Set<string>(),
+      getPlugin: (id: string): Plugin | undefined => undefined,
+    };
+    app.internalPlugins = {
+      getPluginById: (id: string): InternalPlugin | undefined => internalPlugins.get(id),
+    };
+
+    sut = new CoreNotesAdapter(app);
+  });
+
+  describe('core Daily Notes', () => {
+    it('returns true when the plugin is enabled', () => {
+      internalPlugins.set('daily-notes', { enabled: true });
+
+      expect(sut.isDailyNotesEnabled()).toEqual(true);
+    });
+
+    it('returns false when the plugin is present but disabled', () => {
+      internalPlugins.set('daily-notes', { enabled: false });
+
+      expect(sut.isDailyNotesEnabled()).toEqual(false);
+    });
+
+    it('returns false when the plugin is unknown', () => {
+      expect(sut.isDailyNotesEnabled()).toEqual(false);
+    });
+
+    it('returns false when there is no internal plugin manager', () => {
+      app.internalPlugins = undefined as unknown as typeof app.internalPlugins;
+
+      expect(sut.isDailyNotesEnabled()).toEqual(false);
+    });
+
+    it('returns false when the internal plugin manager throws', () => {
+      app.internalPlugins = {
+        getPluginById: (): InternalPlugin | undefined => {
+          throw new Error('nope');
+        },
+      };
+
+      expect(sut.isDailyNotesEnabled()).toEqual(false);
+    });
+  });
+
+  describe('Calendar', () => {
+    it('returns true when the plugin is enabled', () => {
+      app.plugins.enabledPlugins.add('calendar');
+
+      expect(sut.isCalendarEnabled()).toEqual(true);
+    });
+
+    it('returns false when the plugin is unavailable', () => {
+      expect(sut.isCalendarEnabled()).toEqual(false);
+    });
+
+    it('returns false when the plugin manager throws', () => {
+      app.plugins = undefined as unknown as typeof app.plugins;
+
+      expect(sut.isCalendarEnabled()).toEqual(false);
+    });
+  });
+});

--- a/src/__tests__/tasks/provider.test.ts
+++ b/src/__tests__/tasks/provider.test.ts
@@ -36,7 +36,12 @@ describe('tasks provider', () => {
     dailyNote.getPrevious = jest.fn().mockReturnValue(new TFile());
     dailyNote.isValid = jest.fn();
     weeklyNote = jest.fn() as unknown as WeeklyNote;
-    settings = Object.assign({}, DEFAULT_SETTINGS);
+    // Deep copy - the periodicity settings are nested, so a shallow copy would
+    // share them between tests
+    settings = Object.assign({}, DEFAULT_SETTINGS, {
+      daily: Object.assign({}, DEFAULT_SETTINGS.daily),
+      weekly: Object.assign({}, DEFAULT_SETTINGS.weekly),
+    });
     jest.spyOn(AutoTasks, 'getSettings').mockReturnValue(settings);
 
     sut = new TasksProvider(vault, kanban, taskFactory, dailyNote, weeklyNote);
@@ -70,12 +75,15 @@ describe('tasks provider', () => {
   it('does nothing when the provided file is invalid', async () => {
     settings.daily.available = true;
     settings.daily.carryOver = true;
+    jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(new TFile());
     jest.spyOn(dailyNote, 'isValid').mockReturnValue(false);
     const vaultRead = jest.spyOn(vault, 'read');
+    const vaultProcess = jest.spyOn(vault, 'process');
 
     await sut.checkAndCopyTasks(settings, new TFile());
 
     expect(vaultRead).not.toHaveBeenCalled();
+    expect(vaultProcess).not.toHaveBeenCalled();
   });
 
   it('does nothing when there is no current note to copy into', async () => {
@@ -677,6 +685,107 @@ describe('tasks provider', () => {
       expect(processed.get(currentFile)).toContain('- [ ] Due elsewhere');
       expect(processed.get(previousFile)).not.toContain('Due elsewhere');
       expect(processed.get(previousFile)).toContain('- [>] Incomplete 1');
+    });
+  });
+
+  describe('startup catch up', () => {
+    const recentFile = (path: string, ageMs: number = 0): TFile => {
+      const file = new TFile();
+      file.path = path;
+      file.stat = { ctime: Date.now() - ageMs, mtime: Date.now(), size: 0 };
+      return file;
+    };
+
+    beforeEach(() => {
+      settings.daily.available = true;
+      settings.daily.carryOver = true;
+      settings.daily.header = '## Daily TODOs';
+      jest.spyOn(vault, 'read').mockResolvedValue('## TODOs\n\n- [ ] Incomplete 1');
+      jest.spyOn(dailyNote, 'getPrevious').mockReturnValue(new TFile());
+    });
+
+    it('carries over into a note created just before the listener existed', async () => {
+      const currentFile = recentFile('Daily/2026-08-26.md');
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(currentFile);
+      let result;
+      jest.spyOn(vault, 'process').mockImplementation((file, fn) => {
+        result = fn('');
+        return Promise.resolve(result);
+      });
+
+      const carried = await sut.catchUpOnStartup(settings);
+
+      expect(carried).toBe(true);
+      expect(result).toEqual('\n\n## Daily TODOs\n\n- [ ] Incomplete 1');
+      expect(settings.daily.lastCarriedOver).toEqual('Daily/2026-08-26.md');
+    });
+
+    it('does not touch a note that was created too long ago', async () => {
+      jest
+        .spyOn(dailyNote, 'getCurrent')
+        .mockReturnValue(recentFile('Daily/2026-08-26.md', 300000));
+      const vaultProcess = jest.spyOn(vault, 'process');
+
+      const carried = await sut.catchUpOnStartup(settings);
+
+      expect(carried).toBe(false);
+      expect(vaultProcess).not.toHaveBeenCalled();
+    });
+
+    it('does not touch a note with no creation time', async () => {
+      const currentFile = new TFile();
+      currentFile.path = 'Daily/2026-08-26.md';
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(currentFile);
+      const vaultProcess = jest.spyOn(vault, 'process');
+
+      const carried = await sut.catchUpOnStartup(settings);
+
+      expect(carried).toBe(false);
+      expect(vaultProcess).not.toHaveBeenCalled();
+    });
+
+    it('does not repeat what the create event already did', async () => {
+      const currentFile = recentFile('Daily/2026-08-26.md');
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(currentFile);
+      jest.spyOn(dailyNote, 'isValid').mockReturnValue(true);
+      jest.spyOn(vault, 'process').mockImplementation((file, fn) => Promise.resolve(fn('')));
+
+      const carriedOnCreate = await sut.checkAndCopyTasks(settings, currentFile);
+
+      const vaultProcess = jest.spyOn(vault, 'process');
+      vaultProcess.mockClear();
+      const carriedOnCatchUp = await sut.catchUpOnStartup(settings);
+
+      expect(carriedOnCreate).toBe(true);
+      expect(carriedOnCatchUp).toBe(false);
+      expect(vaultProcess).not.toHaveBeenCalled();
+    });
+
+    it('does not carry into the same note twice from repeated create events', async () => {
+      const currentFile = recentFile('Daily/2026-08-26.md');
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(currentFile);
+      jest.spyOn(dailyNote, 'isValid').mockReturnValue(true);
+      jest.spyOn(vault, 'process').mockImplementation((file, fn) => Promise.resolve(fn('')));
+
+      expect(await sut.checkAndCopyTasks(settings, currentFile)).toBe(true);
+      expect(await sut.checkAndCopyTasks(settings, currentFile)).toBe(false);
+    });
+
+    it('does nothing when carry over is disabled', async () => {
+      settings.daily.carryOver = false;
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(recentFile('Daily/2026-08-26.md'));
+      const vaultProcess = jest.spyOn(vault, 'process');
+
+      expect(await sut.catchUpOnStartup(settings)).toBe(false);
+      expect(vaultProcess).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there is no current note', async () => {
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(undefined);
+      const vaultProcess = jest.spyOn(vault, 'process');
+
+      expect(await sut.catchUpOnStartup(settings)).toBe(false);
+      expect(vaultProcess).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from 'obsidian-periodic-notes-provider';
 import { LOADED, SETTINGS_UPDATED } from './events';
 import { KanbanProvider } from './kanban/provider';
+import { CoreNotesAdapter } from './plugins/core-notes';
 import { KanbanPluginAdapter } from './plugins/kanban';
 import { TasksPluginAdapter } from './plugins/tasks';
 import { DEFAULT_SETTINGS, type ISettings } from './settings';
@@ -18,6 +19,7 @@ export default class AutoTasks extends Plugin {
   // Public because Obsidian's declarative settings API reads `plugin.settings`
   public settings: ISettings = DEFAULT_SETTINGS;
   private periodicNotesPlugin: PeriodicNotesPluginAdapter;
+  private coreNotes: CoreNotesAdapter;
   private tasksPlugin: TasksPluginAdapter;
   private taskFactory: TaskFactory;
   private kanbanPlugin: KanbanPluginAdapter;
@@ -32,6 +34,7 @@ export default class AutoTasks extends Plugin {
     const vault: ObsidianVault = app.vault;
 
     this.periodicNotesPlugin = new PeriodicNotesPluginAdapter(app);
+    this.coreNotes = new CoreNotesAdapter(app);
     this.tasksPlugin = new TasksPluginAdapter(app);
     this.kanbanPlugin = new KanbanPluginAdapter(app);
 
@@ -155,8 +158,20 @@ export default class AutoTasks extends Plugin {
     // against the native defaults otherwise - either way this never throws
     debug('Resolving the available periodic note types');
     const pluginSettings = this.periodicNotesPlugin.convertSettings();
-    this.settings.daily.available = pluginSettings.daily.available;
-    this.settings.weekly.available = pluginSettings.weekly.available;
+
+    // The Periodic Notes plugin is not the only source of periodic notes. When
+    // it is installed but a periodicity is turned off in it, note lookup still
+    // falls back to the core Daily Notes plugin, or to Calendar for weekly, so
+    // those count as available too - without this a vault that uses core Daily
+    // Notes for its dailies looks like it has none at all and nothing runs
+    this.settings.daily.available =
+      pluginSettings.daily.available || this.coreNotes.isDailyNotesEnabled();
+    this.settings.weekly.available =
+      pluginSettings.weekly.available || this.coreNotes.isCalendarEnabled();
+
+    debug(
+      `Periodic notes available - daily: ${String(this.settings.daily.available)}, weekly: ${String(this.settings.weekly.available)}`
+    );
     void this.updateSettings(this.settings);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,20 @@ export default class AutoTasks extends Plugin {
     // Copy tasks over when a new daily/weekly note is created
     this.registerEvent(
       this.app.vault.on('create', (file) => {
-        void this.tasks.checkAndCopyTasks(this.settings, file);
+        void this.tasks.checkAndCopyTasks(this.settings, file).then((carried) => {
+          if (carried) {
+            return this.updateSettings(this.settings);
+          }
+        });
       })
     );
+
+    // The core Daily Notes plugin can create today's note while the workspace
+    // is still loading, before the listener above exists - catch that note up
+    // now rather than leaving it without its carried over tasks
+    if (await this.tasks.catchUpOnStartup(this.settings)) {
+      await this.updateSettings(this.settings);
+    }
 
     // Initialize the kanban provider and perform migration if needed
     await this.kanban.initialize();
@@ -144,7 +155,12 @@ export default class AutoTasks extends Plugin {
   async loadSettings(): Promise<void> {
     // loadData() is typed as any, so narrow it before merging over the defaults
     const savedSettings = (await this.loadData()) as Partial<ISettings> | null;
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, savedSettings);
+    // The periodicity settings are nested, so a shallow merge would alias the
+    // shared DEFAULT_SETTINGS objects and then write to them
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, savedSettings, {
+      daily: Object.assign({}, DEFAULT_SETTINGS.daily, savedSettings?.daily),
+      weekly: Object.assign({}, DEFAULT_SETTINGS.weekly, savedSettings?.weekly),
+    });
   }
 
   async updateSettings(settings: ISettings): Promise<void> {

--- a/src/plugins/core-notes.ts
+++ b/src/plugins/core-notes.ts
@@ -1,0 +1,41 @@
+import type { ObsidianAppWithInternalPlugins, ObsidianAppWithPlugins } from '../types';
+
+const DAILY_NOTES_PLUGIN_NAME: string = 'daily-notes';
+const CALENDAR_PLUGIN_NAME: string = 'calendar';
+
+/**
+ * Reports whether Obsidian's own periodic note sources are in play.
+ *
+ * The Periodic Notes plugin is not the only way to end up with daily or weekly
+ * notes - the core Daily Notes plugin and the Calendar plugin both provide them
+ * too. Note lookup already resolves against all three, so availability has to
+ * as well, otherwise a vault using core Daily Notes looks like it has no daily
+ * notes at all.
+ */
+export class CoreNotesAdapter {
+  private app: ObsidianAppWithPlugins & ObsidianAppWithInternalPlugins;
+
+  constructor(app: ObsidianAppWithPlugins & ObsidianAppWithInternalPlugins) {
+    this.app = app;
+  }
+
+  // The core Daily Notes plugin is an internal plugin, so it is not listed in
+  // the community plugin manager
+  isDailyNotesEnabled(): boolean {
+    try {
+      return !!this.app.internalPlugins?.getPluginById(DAILY_NOTES_PLUGIN_NAME)?.enabled;
+    } catch {
+      return false;
+    }
+  }
+
+  // Weekly notes have no core equivalent, but the Calendar plugin supplies the
+  // same settings and is honoured by the note lookup
+  isCalendarEnabled(): boolean {
+    try {
+      return this.app.plugins.enabledPlugins.has(CALENDAR_PLUGIN_NAME);
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -5,6 +5,7 @@ export interface IPeriodicitySettings {
   available: boolean;
   carryOver: boolean;
   header: string;
+  lastCarriedOver: string;
   searchHeaders: string[];
 }
 
@@ -35,6 +36,7 @@ export const DEFAULT_SETTINGS: ISettings = Object.freeze({
     available: false,
     carryOver: false,
     header: '## TODOs',
+    lastCarriedOver: '',
     searchHeaders: [],
   },
   weekly: {
@@ -42,6 +44,7 @@ export const DEFAULT_SETTINGS: ISettings = Object.freeze({
     available: false,
     carryOver: false,
     header: '## TODOs',
+    lastCarriedOver: '',
     searchHeaders: [],
   },
 });

--- a/src/tasks/provider.ts
+++ b/src/tasks/provider.ts
@@ -9,6 +9,11 @@ import { TaskFactory } from './factory';
 import { TASK_CHECKBOX, VALID_STATUS } from './status';
 import { Task } from './task';
 
+// How long after a note is created a startup catch-up will still act on it.
+// The create event is the normal route in; this only covers notes made before
+// the listener was registered, which is a matter of seconds
+const CATCH_UP_WINDOW_MS: number = 60000;
+
 export class TasksProvider {
   private vault: ObsidianVault;
   private kanban: KanbanProvider;
@@ -30,22 +35,77 @@ export class TasksProvider {
     this.weeklyNote = weeklyNote || new WeeklyNote();
   }
 
-  async checkAndCopyTasks(settings: ISettings, file: TAbstractFile): Promise<void> {
-    await this.checkAndCreateForSingleNote(settings, settings.weekly, file, this.weeklyNote);
-    await this.checkAndCreateForSingleNote(settings, settings.daily, file, this.dailyNote);
+  async checkAndCopyTasks(settings: ISettings, file: TAbstractFile): Promise<boolean> {
+    const weekly = await this.checkAndCreateForSingleNote(
+      settings,
+      settings.weekly,
+      file,
+      this.weeklyNote
+    );
+    const daily = await this.checkAndCreateForSingleNote(
+      settings,
+      settings.daily,
+      file,
+      this.dailyNote
+    );
+
+    return weekly || daily;
   }
 
+  /**
+   * Carries tasks over into a note that was created before the create listener
+   * was registered.
+   *
+   * Obsidian's own Daily Notes plugin can create today's note while the
+   * workspace is still loading, which is before onLayoutReady runs and so
+   * before anything is listening for it. Without this the note is simply
+   * missed and no tasks are carried over until the following day.
+   */
+  async catchUpOnStartup(settings: ISettings): Promise<boolean> {
+    const weekly = await this.checkAndCreateForSingleNote(
+      settings,
+      settings.weekly,
+      undefined,
+      this.weeklyNote
+    );
+    const daily = await this.checkAndCreateForSingleNote(
+      settings,
+      settings.daily,
+      undefined,
+      this.dailyNote
+    );
+
+    return weekly || daily;
+  }
+
+  // `file` is the file from a create event, or undefined for a startup catch-up
   private async checkAndCreateForSingleNote(
     settings: ISettings,
     periodicitySetting: IPeriodicitySettings,
-    file: TAbstractFile,
+    file: TAbstractFile | undefined,
     cls: PeriodicNote
-  ): Promise<void> {
-    if (periodicitySetting.available && periodicitySetting.carryOver && cls.isValid(file)) {
+  ): Promise<boolean> {
+    if (periodicitySetting.available && periodicitySetting.carryOver) {
       const newNote = cls.getCurrent();
       if (newNote === undefined) {
         debug('No current note to copy tasks into, skipping');
-        return;
+        return false;
+      }
+
+      // Never carry into the same note twice - the create event can fire more
+      // than once, and a catch-up must not repeat what the event already did
+      if (newNote.path && periodicitySetting.lastCarriedOver === newNote.path) {
+        debug(`Tasks have already been carried over into ${newNote.path}, skipping`);
+        return false;
+      }
+
+      if (file !== undefined) {
+        if (!cls.isValid(file)) {
+          return false;
+        }
+      } else if (!this.wasCreatedRecently(newNote)) {
+        debug('Current note was not created recently enough to catch up on, skipping');
+        return false;
       }
 
       // Get the previous entry - there may not be one, in which case there is
@@ -109,7 +169,20 @@ export class TasksProvider {
       if (previousEntry !== undefined) {
         await this.markCarriedOverTasks(settings, previousEntry, carriedOverLines);
       }
+
+      periodicitySetting.lastCarriedOver = newNote.path;
+
+      return true;
     }
+
+    return false;
+  }
+
+  private wasCreatedRecently(note: TFile): boolean {
+    // stat is absent on some mocked and remote files - treat an unknown
+    // creation time as too old to act on rather than risk a duplicate
+    const created = note.stat?.ctime;
+    return created !== undefined && created > Date.now() - CATCH_UP_WINDOW_MS;
   }
 
   // The raw source line of every task being carried over, including the nested

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,7 +10,19 @@ export interface CommunityPluginManager {
 export type ObsidianAppWithPlugins = {
   plugins: CommunityPluginManager;
 };
-export type ObsidianApp = App & ObsidianAppWithPlugins;
+
+export interface InternalPlugin {
+  enabled: boolean;
+}
+
+export interface InternalPluginManager {
+  getPluginById(id: string): InternalPlugin | undefined;
+}
+
+export type ObsidianAppWithInternalPlugins = {
+  internalPlugins: InternalPluginManager;
+};
+export type ObsidianApp = App & ObsidianAppWithPlugins & ObsidianAppWithInternalPlugins;
 export type ObsidianVault = {
   getFileByPath(path: string): TFile | null;
   create(path: string, data: string, options?: DataWriteOptions): Promise<TFile>;


### PR DESCRIPTION
Closes #62

Tasks were never copied over in a vault that uses Obsidian's core Daily Notes plugin. Two separate causes.

## Availability was read from the wrong place

`syncPeriodicNotesSettings` took `daily.available` solely from the Periodic Notes plugin, and `checkAndCreateForSingleNote` bails on that as its first condition. With Periodic Notes installed but its daily periodicity turned off — the natural setup when core Daily Notes is handling dailies — availability came back false and nothing ran at all.

Note lookup never had this problem. The provider package already resolves the folder and format from the core Daily Notes plugin when Periodic Notes' daily is disabled, and from Calendar for weekly, so `getCurrent()`, `getPrevious()` and `isValid()` would all have worked. Only the availability check disagreed with the lookup, which is why the plugin failed silently rather than half-working.

A periodicity is now treated as available when either the Periodic Notes plugin reports it or the corresponding core source is enabled.

## The create event could fire before anything was listening

The create listener is registered in `onLayoutReady`, but core Daily Notes can create today's note while the workspace is still loading. When it wins that race the note is missed entirely, and `PeriodicNote.isValid` only accepts files created in the last 15 seconds so there is no late catch.

Layout ready now checks for a recently created current note and carries into it if the event was missed. Two guards stop this duplicating anything: a creation-time window, and a new per-periodicity record of the last note carried into. The second also fixes duplicate carry over if a create event ever fires twice.

## Settings merge

`loadSettings` shallow merged over `DEFAULT_SETTINGS`, so `settings.daily` aliased the shared defaults object and runtime writes landed in the module-level constant. Merged a level deeper now that a field is written during normal operation.