### PR TITLE
fix: handle a missing periodic note without throwing

### DIFF
--- a/src/__tests__/tasks/provider.test.ts
+++ b/src/__tests__/tasks/provider.test.ts
@@ -788,4 +788,63 @@ describe('tasks provider', () => {
       expect(vaultProcess).not.toHaveBeenCalled();
     });
   });
+
+  describe('missing notes', () => {
+    // The periodic note lookup is typed as returning TFile | undefined but
+    // actually hands back null when there is no note for the period
+    const returnsNoNote = () => jest.fn().mockReturnValue(null);
+
+    beforeEach(() => {
+      settings.daily.available = true;
+      settings.daily.carryOver = true;
+      settings.daily.header = '## Daily TODOs';
+    });
+
+    it('does not throw on startup when there is no current note', async () => {
+      dailyNote.getCurrent = returnsNoNote();
+      const vaultProcess = jest.spyOn(vault, 'process');
+
+      await expect(sut.catchUpOnStartup(settings)).resolves.toBe(false);
+      expect(vaultProcess).not.toHaveBeenCalled();
+    });
+
+    it('does not throw on create when there is no current note', async () => {
+      dailyNote.getCurrent = returnsNoNote();
+      jest.spyOn(dailyNote, 'isValid').mockReturnValue(true);
+      const vaultProcess = jest.spyOn(vault, 'process');
+
+      await expect(sut.checkAndCopyTasks(settings, new TFile())).resolves.toBe(false);
+      expect(vaultProcess).not.toHaveBeenCalled();
+    });
+
+    it('adds the header without reading when there is no previous note', async () => {
+      const currentFile = new TFile();
+      currentFile.path = 'Daily/2026-08-26.md';
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(currentFile);
+      dailyNote.getPrevious = returnsNoNote();
+      jest.spyOn(dailyNote, 'isValid').mockReturnValue(true);
+      const vaultRead = jest.spyOn(vault, 'read');
+      let result;
+      jest.spyOn(vault, 'process').mockImplementation((file, fn) => {
+        result = fn('');
+        return Promise.resolve(result);
+      });
+
+      await expect(sut.checkAndCopyTasks(settings, currentFile)).resolves.toBe(true);
+
+      expect(vaultRead).not.toHaveBeenCalled();
+      expect(result).toEqual('\n\n## Daily TODOs\n\n');
+    });
+
+    it('does not throw when both the current and previous notes are missing', async () => {
+      settings.weekly.available = true;
+      settings.weekly.carryOver = true;
+      weeklyNote.getCurrent = returnsNoNote();
+      weeklyNote.getPrevious = returnsNoNote();
+      weeklyNote.isValid = jest.fn().mockReturnValue(false);
+      dailyNote.getCurrent = returnsNoNote();
+
+      await expect(sut.catchUpOnStartup(settings)).resolves.toBe(false);
+    });
+  });
 });

--- a/src/tasks/provider.ts
+++ b/src/tasks/provider.ts
@@ -86,8 +86,11 @@ export class TasksProvider {
     cls: PeriodicNote
   ): Promise<boolean> {
     if (periodicitySetting.available && periodicitySetting.carryOver) {
+      // The periodic note lookup is typed as returning TFile | undefined but
+      // actually returns null when there is no note for the period, so every
+      // result from it has to be checked for both
       const newNote = cls.getCurrent();
-      if (newNote === undefined) {
+      if (!newNote) {
         debug('No current note to copy tasks into, skipping');
         return false;
       }
@@ -111,8 +114,9 @@ export class TasksProvider {
       // Get the previous entry - there may not be one, in which case there is
       // nothing to carry over, though due tasks can still apply below
       const previousEntry = cls.getPrevious();
-      const previousEntryContents: string =
-        previousEntry !== undefined ? await this.vault.read(previousEntry) : '';
+      const previousEntryContents: string = previousEntry
+        ? await this.vault.read(previousEntry)
+        : '';
       const tasks: Task[] = this.factory
         .newCollection(previousEntryContents)
         .getTasksFromLists(periodicitySetting.searchHeaders);
@@ -166,7 +170,7 @@ export class TasksProvider {
 
       // Mark the tasks that have just been carried forward in the note they
       // came from, so they stop reading as outstanding in queries elsewhere
-      if (previousEntry !== undefined) {
+      if (previousEntry) {
         await this.markCarriedOverTasks(settings, previousEntry, carriedOverLines);
       }
 


### PR DESCRIPTION
Fixes a crash on load introduced in v0.11.1:

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'path')
    at checkAndCreateForSingleNote
    at catchUpOnStartup
    at onLayoutReady
```

## Cause

The periodic note lookup is typed as returning `TFile | undefined`, but the implementation returns `null` when there is no note for the period:

```js
function Be(t, e) { var r; return (r = e[T(t, "day")]) != null ? r : null }
```

`getPrevious()` passes the same value straight back. Every check in the provider tested against `undefined`, so none of them matched a null and the next property access threw.

It surfaces with daily notes enabled and no Periodic Notes plugin: the native provider reports *every* periodicity as available, so the startup catch-up runs for weekly too, finds no weekly note, and reads `path` off null.

## Fix

Check the lookup results for truthiness rather than against `undefined`. This also fixes a longstanding case on the create path — a vault whose first ever periodic note has no predecessor passed null to `vault.read`, which is a separate crash that predates the catch-up.

Four regression tests cover it, each verified to fail on the previous commit with the reported error.