### PR TITLE
fix: carry over again when a note is deleted and recreated

### DIFF
--- a/src/__tests__/tasks/provider.test.ts
+++ b/src/__tests__/tasks/provider.test.ts
@@ -847,4 +847,62 @@ describe('tasks provider', () => {
       await expect(sut.catchUpOnStartup(settings)).resolves.toBe(false);
     });
   });
+
+  describe('recreated notes', () => {
+    const noteAt = (path: string, ctime: number): TFile => {
+      const file = new TFile();
+      file.path = path;
+      file.stat = { ctime, mtime: ctime, size: 0 };
+      return file;
+    };
+
+    beforeEach(() => {
+      settings.daily.available = true;
+      settings.daily.carryOver = true;
+      settings.daily.header = '## Daily TODOs';
+      jest.spyOn(vault, 'read').mockResolvedValue('## TODOs\n\n- [ ] Incomplete 1');
+      jest.spyOn(dailyNote, 'getPrevious').mockReturnValue(new TFile());
+      jest.spyOn(dailyNote, 'isValid').mockReturnValue(true);
+      jest.spyOn(vault, 'process').mockImplementation((file, fn) => Promise.resolve(fn('')));
+    });
+
+    it('carries over again when a note is deleted and recreated at the same path', async () => {
+      const original = noteAt('Daily/2026-08-26.md', 1000);
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(original);
+      expect(await sut.checkAndCopyTasks(settings, original)).toBe(true);
+
+      // Same path, but made again - a different note as far as this is concerned
+      const recreated = noteAt('Daily/2026-08-26.md', 2000);
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(recreated);
+
+      expect(await sut.checkAndCopyTasks(settings, recreated)).toBe(true);
+      expect(settings.daily.lastCarriedOverAt).toEqual(2000);
+    });
+
+    it('still skips a repeated event for the very same note', async () => {
+      const note = noteAt('Daily/2026-08-26.md', 1000);
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(note);
+
+      expect(await sut.checkAndCopyTasks(settings, note)).toBe(true);
+      expect(await sut.checkAndCopyTasks(settings, note)).toBe(false);
+    });
+
+    it('falls back to the path when the note has no creation time', async () => {
+      const note = new TFile();
+      note.path = 'Daily/2026-08-26.md';
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(note);
+
+      expect(await sut.checkAndCopyTasks(settings, note)).toBe(true);
+      expect(await sut.checkAndCopyTasks(settings, note)).toBe(false);
+    });
+
+    it('carries over into a different note at a different path', async () => {
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(noteAt('Daily/2026-08-26.md', 1000));
+      expect(await sut.checkAndCopyTasks(settings, new TFile())).toBe(true);
+
+      jest.spyOn(dailyNote, 'getCurrent').mockReturnValue(noteAt('Daily/2026-08-27.md', 3000));
+      expect(await sut.checkAndCopyTasks(settings, new TFile())).toBe(true);
+      expect(settings.daily.lastCarriedOver).toEqual('Daily/2026-08-27.md');
+    });
+  });
 });

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -6,6 +6,7 @@ export interface IPeriodicitySettings {
   carryOver: boolean;
   header: string;
   lastCarriedOver: string;
+  lastCarriedOverAt: number;
   searchHeaders: string[];
 }
 
@@ -37,6 +38,7 @@ export const DEFAULT_SETTINGS: ISettings = Object.freeze({
     carryOver: false,
     header: '## TODOs',
     lastCarriedOver: '',
+    lastCarriedOverAt: 0,
     searchHeaders: [],
   },
   weekly: {
@@ -45,6 +47,7 @@ export const DEFAULT_SETTINGS: ISettings = Object.freeze({
     carryOver: false,
     header: '## TODOs',
     lastCarriedOver: '',
+    lastCarriedOverAt: 0,
     searchHeaders: [],
   },
 });

--- a/src/tasks/provider.ts
+++ b/src/tasks/provider.ts
@@ -116,14 +116,34 @@ export class TasksProvider {
       // Get the previous entry - there may not be one, in which case there is
       // nothing to carry over, though due tasks can still apply below
       const previousEntry = cls.getPrevious();
+      if (!previousEntry) {
+        debug(
+          `No previous note found to carry tasks from - the ${periodicitySetting.header} header will be added empty`
+        );
+      } else {
+        debug(`Carrying tasks from ${previousEntry.path} into ${newNote.path}`);
+      }
+
       const previousEntryContents: string = previousEntry
         ? await this.vault.read(previousEntry)
         : '';
       const tasks: Task[] = this.factory
         .newCollection(previousEntryContents)
         .getTasksFromLists(periodicitySetting.searchHeaders);
+      if (previousEntry) {
+        const headers = periodicitySetting.searchHeaders.length
+          ? `header(s) ${periodicitySetting.searchHeaders.toString()}`
+          : 'the whole note';
+        debug(`Found ${tasks.length} task(s) in ${previousEntry.path} searching ${headers}`);
+      }
+
       // Only plain open checkboxes carry over, then recursively filter children
       let tasksToAdd: Task[] = tasks.filter((task) => task.isOpen());
+      if (tasks.length && !tasksToAdd.length) {
+        debug(
+          `None of the ${tasks.length} task(s) are open - only a plain "- [ ]" checkbox is carried over`
+        );
+      }
       for (const task of tasksToAdd) {
         task.filterNonOpenChildren();
         // Reset indent levels to start from 0 for carried over tasks
@@ -157,6 +177,8 @@ export class TasksProvider {
       if (settings.carryOverPrefix) {
         tasksToAdd = tasksToAdd.map((task) => task.markCarriedOver());
       }
+
+      debug(`Carrying ${tasksToAdd.length} task(s) over into ${newNote.path}`);
 
       // Add them into the new entry
       await this.vault.process(newNote, (contents) => {

--- a/src/tasks/provider.ts
+++ b/src/tasks/provider.ts
@@ -96,8 +96,10 @@ export class TasksProvider {
       }
 
       // Never carry into the same note twice - the create event can fire more
-      // than once, and a catch-up must not repeat what the event already did
-      if (newNote.path && periodicitySetting.lastCarriedOver === newNote.path) {
+      // than once, and a catch-up must not repeat what the event already did.
+      // The creation time is part of the comparison so that deleting a note and
+      // making it again is treated as a new note rather than one already done
+      if (this.hasAlreadyCarriedOver(periodicitySetting, newNote)) {
         debug(`Tasks have already been carried over into ${newNote.path}, skipping`);
         return false;
       }
@@ -175,11 +177,27 @@ export class TasksProvider {
       }
 
       periodicitySetting.lastCarriedOver = newNote.path;
+      periodicitySetting.lastCarriedOverAt = newNote.stat?.ctime ?? 0;
 
       return true;
     }
 
     return false;
+  }
+
+  private hasAlreadyCarriedOver(periodicitySetting: IPeriodicitySettings, note: TFile): boolean {
+    if (!note.path || periodicitySetting.lastCarriedOver !== note.path) {
+      return false;
+    }
+
+    // A note with no creation time cannot be told apart from a replacement, so
+    // fall back to the path alone rather than carrying over repeatedly
+    const created = note.stat?.ctime;
+    if (created === undefined) {
+      return true;
+    }
+
+    return periodicitySetting.lastCarriedOverAt === created;
   }
 
   private wasCreatedRecently(note: TFile): boolean {


### PR DESCRIPTION
## The guard was permanent

The guard added in v0.11.1 to stop a note being carried into twice keyed on the note path alone, and that value is persisted to `data.json`. Deleting a daily note and creating it again therefore produced nothing — the path had been seen before, so carry over was skipped permanently, with only a debug line to say why:

```
[JH:AT] Tasks have already been carried over into 2026-08-26.md, skipping
```

That is the exact sequence someone follows to test the plugin, and the one reported in #62 — delete the note, restart, expect tasks.

The creation time is now recorded alongside the path and both must match. A replacement note has a new `ctime` so it is treated as new, while a repeated create event for the same note is still skipped. A note with no creation time falls back to matching on path alone rather than risking repeated carry over.

Anyone already affected is fixed by this without touching `data.json`: the stored `lastCarriedOverAt` defaults to 0 and will not match any real note's creation time.

## Carry over now says what it did

There was no logging between finding the current note and writing the header, so an empty task list gave no indication why. It now reports the note being carried from, how many tasks were read and where they were searched for, how many were carried, and calls out the two cases that produce an empty list:

```
[JH:AT] Carrying tasks from Daily/2026-08-25.md into Daily/2026-08-26.md
[JH:AT] Found 4 task(s) in Daily/2026-08-25.md searching the whole note
[JH:AT] Carrying 3 task(s) over into Daily/2026-08-26.md
```
```
[JH:AT] No previous note found to carry tasks from - the ## TODOs header will be added empty
[JH:AT] None of the 4 task(s) are open - only a plain "- [ ]" checkbox is carried over
```